### PR TITLE
Proposed  changes

### DIFF
--- a/refunds.md
+++ b/refunds.md
@@ -14,35 +14,36 @@ SiRA is a membership organization with members that pay annual dues. Refunds wil
 ## SiRA Events
 
 SiRA will host Events from time to time, including but not limited to: webinars, SiRAcon, trainings, seminars, etc. These events may be offered for free to the public, for free to members, for a cost to public or members, or some combination thereof.
+Unless posted otherwise for a specific event the below is SiRA's refund schedule.
 
-## Event Registration
+### Event Registration
 
 Some SiRA Events will have defined timelines around registration and refund deadlines. For example, "early bird" discounts, member discounts, student discounts, registration cut-offs, etc. Virtual Event registration will generally cut off on the day of the event. In-person events may have registration cut-offs in advance of the event. Refunds will similarly have a cut-off in advance of the event, usually around the time that final seating counts must be provided to facilities, caterers, etc. 
 
-## Event Refunds
+### Event Refunds
 
 If a registered attendee for a SiRA Event is unable to attend, and does not wish to transfer their ticket/seat to another individual, they may request a refund for the originally paid registration expense, taking into account any discounts that may have been in effect. As long as these requests are received within any stated timeframes for the event, SiRA will attempt to honor these requests and issue a refund **to the original payment method** that was used to make payment. Any refunded amounts will be minus any transactional fees (e.g., credit card transaction fees) that may have been charged for the original payment, and minus any additional fees that may be charged as part of processing the refund.
 
 If a request for refund is not made within the stated timeframe for the event, SiRA may still choose to issue a partial refund as a courtesy to the registrant.
 
-## Example Timeframe
+Ticket transfers may occur up to five (5) days prior to the event. Transfers should be directed to the organizers of the event, for example <siracon@societyinforisk.org>, <events@societyinforisk.org>, or <webinars@societyinforisk.org>.
 
-This section is an example only, and any specific timing requirements will be posted along with event registration information.
+### Refund Timetable
 
-SiRAcon events have several types of registrations. These generally include: 
+Events often have several types of registrations. These generally include: 
 
 * early-bird pricing: available until 90 days before the event
-* member pricing: a $50 discount for current and paid members of SiRA
-* complimentary: generally provided to speakers, SiRA board members, SiRAcon organizers/volunteers, and vendors and their guests as part of sponsorship packages
+* member pricing: a discounted price for current and paid members of SiRA
+* complimentary: generally provided to speakers, SiRA board members, event organizers/volunteers, and vendors and their guests as part of sponsorship packages
 
-SiRAcon refunds will generally be honored as follows:
-* 60+ days ahead of the event: 100% refund, minus applicable fees.
-* 30-59 days ahead of the event: 50% refund, minus applicable fees.
-* 14-29 days ahead of the event: 25% refund, minus applicable fees.
+Event refunds will generally be honored as follows:
+
+* 30+ days ahead of the event: 100% refund, minus applicable fees.
+* 14-29 days ahead of the event: 50% refund, minus applicable fees.
 * 13 days or less ahead of the event: no refund
 
 Timing for completing a refund will vary, and is on a best-effort basis.
 
 ## Refund Requests
 
-Requests for refund should generally be directed to the organizers of the event, for example <siracon@societyinforisk.org> or <webinars@societyinforisk.org>. As a last resort, or if you are unsure who to contact, please reach out to <board@societyinforisk.org> or <payments@societyinforisk.org>. 
+Requests for refund should generally be directed to the organizers of the event, for example <siracon@societyinforisk.org>, <events@societyinforisk.org>, or <webinars@societyinforisk.org>. As a last resort, or if you are unsure who to contact, please reach out to <board@societyinforisk.org> or <payments@societyinforisk.org>. 


### PR DESCRIPTION
Simplifying the window to just two refund opportunities. Changed language to events instead of specifying SiRAcon  Created opportunity for Events to specify their own refund policy Added transfer window limitation